### PR TITLE
Change back to Teamspeak 3 version 3.0.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG="en_US.UTF-8" \
     SINUS_DIR="/sinusbot" \
     YTDL_BIN="/usr/local/bin/youtube-dl" \
     YTDL_VERSION="latest" \
-    TS3_VERSION="3.0.18.2" \
+    TS3_VERSION="3.0.19.4" \
     TS3_DL_ADDRESS="http://teamspeak.gameserver.gamed.de/ts3/releases/" \
     SINUSBOT_DL_URL="https://www.sinusbot.com/dl/sinusbot-beta.tar.bz2"
 


### PR DESCRIPTION
```
The version of teamspeak doesn't change anything for the issue 'with ram' but sometimes block to access to some servers where the lowest version of teamspeak is 3.0.19.4
```