### PR TITLE
Update for new Sinusbot Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-MAINTAINER Alexander Trost <galexrt@googlemail.com>
+MAINTAINER horstexplorer
 
 ENV LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8 " \
@@ -9,41 +9,47 @@ ENV LANG="en_US.UTF-8" \
     SINUS_DIR="/sinusbot" \
     YTDL_BIN="/usr/local/bin/youtube-dl" \
     YTDL_VERSION="latest" \
-    TS3_VERSION="3.0.18.2" \
-    TS3_DL_ADDRESS="http://teamspeak.gameserver.gamed.de/ts3/releases/" \
-    SINUSBOT_DL_URL="https://www.sinusbot.com/dl/sinusbot-beta.tar.bz2"
+    TS3_VERSION="3.1.8" \
+    TS3_DL_ADDRESS="http://dl.4players.de/ts/releases/" \
+    SINUSBOT_DL_URL="https://www.sinusbot.com/dl/sinusbot.current.tar.bz2"
 
 ENV SINUS_DATA="$SINUS_DIR/data" \
     SINUS_DATA_SCRIPTS="$SINUS_DIR/scripts" \
     TS3_DIR="$SINUS_DIR/TeamSpeak3-Client-linux_amd64"
 
 RUN groupadd -g "$SINUS_GROUP" sinusbot && \
-    useradd -u "$SINUS_USER" -g "$SINUS_GROUP" -d "$SINUS_DIR" sinusbot && \
-    apt-get -q update -y && \
+    useradd -u "$SINUS_USER" -g "$SINUS_GROUP" -d "$SINUS_DIR" sinusbot
+    
+RUN apt-get -q update -y && \
     apt-get -q upgrade -y && \
-    apt-get -q install -y x11vnc xvfb libxcursor1 ca-certificates bzip2 \
+    apt-get -q install -y x11vnc xvfb libxcursor1 ca-certificates bzip2 libnss3 libegl1-mesa x11-xkb-utils libasound2 \
         libglib2.0-0 libnss3 locales wget sudo python less && \
     locale-gen --purge "$LANG" && \
     update-locale LANG="$LANG" && \
     echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale && \
     echo "LANG=en_US.UTF-8" >> /etc/default/locale && \
-    update-ca-certificates && \
-    mkdir -p "$SINUS_DIR" && \
+    update-ca-certificates
+    
+RUN mkdir -p "$SINUS_DIR" && \
     wget -qO- "$SINUSBOT_DL_URL" | \
     tar -xjf- -C "$SINUS_DIR" && \
     mv "$SINUS_DATA_SCRIPTS" "$SINUS_DATA_SCRIPTS-orig" && \
     cp -f "$SINUS_DIR/config.ini.dist" "$SINUS_DIR/config.ini" && \
-    sed -i 's|^DataDir.*|DataDir = '"$SINUS_DATA"'|g' "$SINUS_DIR/config.ini" && \
-    mkdir -p "$TS3_DIR" && \
+    sed -i 's|^DataDir.*|DataDir = '"$SINUS_DATA"'|g' "$SINUS_DIR/config.ini" 
+    
+RUN mkdir -p "$TS3_DIR" && \
     cd "$SINUS_DIR" || exit 1 && \
     wget -q -O "TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" \
         "$TS3_DL_ADDRESS/$TS3_VERSION/TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
     chmod 755 "TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
     yes | "./TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
     rm -f "TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
+    rm TeamSpeak3-Client-linux_amd64/xcbglintegrations/libqxcb-glx-integration.so && \
+    mkdir TeamSpeak3-Client-linux_amd64/plugins && \
     cp -f "$SINUS_DIR/plugin/libsoundbot_plugin.so" "$TS3_DIR/plugins/" && \
-    sed -i "s|^TS3Path.*|TS3Path = \"$TS3_DIR/ts3client_linux_amd64\"|g" "$SINUS_DIR/config.ini" && \
-    wget -q -O "$YTDL_BIN" "https://yt-dl.org/downloads/$YTDL_VERSION/youtube-dl" && \
+    sed -i "s|^TS3Path.*|TS3Path = \"$TS3_DIR/ts3client_linux_amd64\"|g" "$SINUS_DIR/config.ini"
+    
+RUN wget -q -O "$YTDL_BIN" "https://yt-dl.org/downloads/$YTDL_VERSION/youtube-dl" && \
     chmod 755 -f "$YTDL_BIN" && \
     echo "YoutubeDLPath = \"$YTDL_BIN\"" >> "$SINUS_DIR/config.ini" && \
     chown -fR sinusbot:sinusbot "$SINUS_DIR" && \

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-# docker-sinusbot
-
-[![](https://images.microbadger.com/badges/image/galexrt/sinusbot.svg)](https://microbadger.com/images/galexrt/sinusbot "Get your own image badge on microbadger.com")
-
-[![Docker Repository on Quay.io](https://quay.io/repository/galexrt/sinusbot/status "Docker Repository on Quay.io")](https://quay.io/repository/galexrt/sinusbot)
+# Docker-sinusbot
 
 Image available from:
-* [**Quay.io**](https://quay.io/repository/galexrt/sinusbot)
-* [**Docker Hub**](https://hub.docker.com/r/galexrt/sinusbot)
+* [**Docker Hub**](http://hub.docker.com/r/horstexplorer/sinusbot/)
 
 Docker Image with Sinusbot by Michael Friese.
 TeamSpeak 3 SinusBot Homepage: https://sinusbot.com/.
 
 Current version:
 ```
-Sinusbot: latest beta (>=0.9.16-10f0fad)
-TeamSpeak: 3.0.18.2 (this version is required for Sinusbot)
+Sinusbot: latest current (>=0.11.0) (auto update)
+TeamSpeak: 3.1.8 (this version is required for Sinusbot >=0.11.0)
 ```
 
 ## Summary
-* Debian Jessie with the latest version of Sinusbot
+* Ubuntu Xenial with the latest version of Sinusbot + automatic updater
 * You can inject your data into the container
   * /data
 
@@ -26,7 +21,7 @@ TeamSpeak: 3.0.18.2 (this version is required for Sinusbot)
 ### Updating the image
 Run the below command, to update the image to the latest version:
 ```
-docker pull quay.io/galexrt/sinusbot:latest
+docker pull horstexplorer/sinusbot
 ```
 
 ### Permissions
@@ -57,7 +52,7 @@ docker run \
     -v /opt/docker/sinusbot/data:/sinusbot/data \
     -v /opt/docker/sinusbot/scripts:/sinusbot/scripts \
     -p 8087:8087 \
-    galexrt/sinusbot:latest
+    horstexplorer/sinusbot:latest
 ```
 
 ### SELinux
@@ -69,7 +64,7 @@ docker run \
     -v /opt/docker/sinusbot/data:/sinusbot/data:z \
     -v /opt/docker/sinusbot/scripts:/sinusbot/scripts:z \
     -p 8087:8087 \
-    galexrt/sinusbot:latest
+    horstexplorer/sinusbot:latest
 ```
 
 ### Getting Sinusbot image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,5 +46,13 @@ echo "=> Updating Youtube-dl..."
 $YTDL_BIN -U
 echo "=> Updated youtube-dl with exit code $?"
 
+echo "=> Updating Sinusbot"
+cd /sinusbot
+wget https://www.sinusbot.com/dl/sinusbot.current.tar.bz2
+tar -xjvf sinusbot.current.tar.bz2
+cp plugin/libsoundbot_plugin.so TeamSpeak3-Client-linux_amd64/plugins/
+chown -R sinusbot /sinusbot
+echo "=> Done"
+
 echo "=> Starting SinusBot (https://sinusbot.com) by Michael Friese ..."
 exec sudo -u sinusbot -g sinusbot "$SINUS_DIR/sinusbot" "$@"


### PR DESCRIPTION
Hey,
I updated the code to work with the newest Sinusbot versions (>0.11) with TS3 version 3.1.8 and added the feature of self updating, so that the Sinusbot will be updated on every start of the container.


entrypoint.sh
+added feature of updating Sinusbot on every start so that it will never be outdated

Dockerfile
+changed maintainer -> need to change it back
+changed TS3-Version to 3.1.8
+changed TS3-Download-Path 
+swap from Sinusbot beta to Sinusbot current (v >0.11.x)
+added new dependencies
+added small changes to code so that the new TS3 version is working

Changes in README.md can be ignored but you may update the Sinusbot and Teamspeak version and correct that the docker is using Ubuntu instead of Debian Jessie

-------------------------------------------------------------------------------------------------------------------
Hey,
Ich habe den Code etwas verändert, damit auch die neusten Sinusbot Versionen (>0.11) welche TS3 3.1.8 benötigen funktionieren. Desweiteren ist noch ein kleines Feature dabei welches den Sinusbot bei jedem Start des Containers erneuert sodass dieser immer aktuell ist. 

entrypoint.sh
+Feature hinzugefügt welches den Sinusbot bei jedem Start erneuert

Dockerfile
+Maintainer geändert -> sollte man wieder rückgängig machen
+TS3-Version auf 3.1.8 geändert
+TS3-Download auf dl.4players.de gelegt
+wechsel von Sinusbot beta zu Sinusbot current (v >0.11.x) um immer die neusten Versionen zu erhalten
+neue Abhänigkeiten hinzugefügt
+kleinere Änderungen im Code


Die README.md kann ignoriert werden, allerdings wäre es gut die Versionen von TeamSpeak und Sinusbot anzupassen und das System von Debian Jessie auf Ubuntu zu korrigieren.